### PR TITLE
fix: fixed env vars populating in codux

### DIFF
--- a/_codux/board-wrappers/page-wrapper.tsx
+++ b/_codux/board-wrappers/page-wrapper.tsx
@@ -1,6 +1,6 @@
 import { isRouteErrorResponse, useNavigate, useRouteError } from '@remix-run/react';
 import { createRemixStub } from '@remix-run/testing';
-import App from 'app/root';
+import App, { loader as rootLoader } from 'app/root';
 import { type PropsWithChildren } from 'react';
 import { ROUTES } from '~/router/config';
 
@@ -21,6 +21,7 @@ export function PageWrapper(props: PageWrapperProps) {
         {
             Component: () => <App />,
             id: 'root',
+            loader: rootLoader,
             children: [
                 ...Object.values(ROUTES).map(({ path }) => ({
                     path,

--- a/_codux/boards/app.board.tsx
+++ b/_codux/boards/app.board.tsx
@@ -1,6 +1,6 @@
 import { createRemixStub } from '@remix-run/testing';
 import { createBoard } from '@wixc3/react-board';
-import App, { ErrorBoundary as rootErrorBoundary } from 'app/root';
+import App, { ErrorBoundary as rootErrorBoundary, loader as rootLoader } from 'app/root';
 import HomePage, { loader as homePageLoader } from 'app/routes/_index/route';
 import AboutPage from 'app/routes/about/route';
 import ProductsPage, { loader as productsPageLoader } from 'app/routes/products/route';
@@ -16,6 +16,7 @@ const AppWrapper = createRemixStub([
         Component: () => {
             return <App />;
         },
+        loader: rootLoader,
         ErrorBoundary: rootErrorBoundary,
         children: [
             {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,8 +25,6 @@ export async function loader() {
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {
-    const data = useLoaderData<typeof loader>();
-
     return (
         <html lang="en">
             <head>
@@ -36,11 +34,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 <Links />
             </head>
             <body>
-                <script
-                    dangerouslySetInnerHTML={{
-                        __html: `window.ENV = ${JSON.stringify(data?.ENV)}`,
-                    }}
-                />
                 {children}
                 <ScrollRestoration />
                 <Scripts />
@@ -50,6 +43,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+    const data = useLoaderData<typeof loader>();
+
+    if (typeof window !== 'undefined' && typeof window.ENV === 'undefined') {
+        window.ENV = data.ENV;
+    }
+
     return (
         <EcomAPIContextProvider>
             <CartOpenContextProvider>

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,6 +1,6 @@
 import { LinksFunction, LoaderFunctionArgs } from '@remix-run/node';
 import { Link, MetaFunction, useLoaderData, useNavigate } from '@remix-run/react';
-import { ecomApi } from '~/api/ecom-api';
+import { getEcomApi } from '~/api/ecom-api';
 import { HeroImage } from '~/components/hero-image/hero-image';
 import { ProductCard } from '~/components/product-card/product-card';
 import { ROUTES } from '~/router/config';
@@ -8,7 +8,7 @@ import { getUrlOriginWithPath } from '~/utils';
 import styles from './index.module.scss';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const products = await ecomApi.getPromotedProducts();
+    const products = await getEcomApi().getPromotedProducts();
     const canonicalUrl = getUrlOriginWithPath(request.url);
 
     return { products, canonicalUrl };

--- a/app/routes/products/route.tsx
+++ b/app/routes/products/route.tsx
@@ -1,6 +1,6 @@
 import { LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
-import { ecomApi } from '~/api/ecom-api';
+import { getEcomApi } from '~/api/ecom-api';
 import { getImageHttpUrl } from '~/api/wix-image';
 import { ProductCard } from '~/components/product-card/product-card';
 import { ROUTES } from '~/router/config';
@@ -8,7 +8,7 @@ import { getUrlOriginWithPath } from '~/utils';
 import styles from './products.module.scss';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const products = await ecomApi.getAllProducts();
+    const products = await getEcomApi().getAllProducts();
 
     return { products, canonicalUrl: getUrlOriginWithPath(request.url) };
 };

--- a/app/routes/products_.$productId/route.tsx
+++ b/app/routes/products_.$productId/route.tsx
@@ -3,7 +3,7 @@ import { isRouteErrorResponse, json, useLoaderData, useRouteError } from '@remix
 import classNames from 'classnames';
 import { useRef } from 'react';
 import { useAddToCart } from '~/api/api-hooks';
-import { ecomApi } from '~/api/ecom-api';
+import { getEcomApi } from '~/api/ecom-api';
 import { useCartOpen } from '~/components/cart/cart-open-context';
 import { Price } from '~/components/price/price';
 import { ProductImages } from '~/components/product-images/product-images';
@@ -21,7 +21,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     if (!params.productId) {
         throw new Error('Missing product id');
     }
-    const product = await ecomApi.getProduct(params.productId);
+    const product = await getEcomApi().getProduct(params.productId);
     if (product === undefined) {
         throw json('Product Not Found', { status: 404 });
     }

--- a/codux.config.json
+++ b/codux.config.json
@@ -35,5 +35,10 @@
       "~/*": "./src/*"
     }
   },
-  "svgLoader": "both"
+  "svgLoader": "both",
+  "previewConfiguration": {
+    "environmentVariables": {
+      "WIX_CLIENT_ID": "0c9d1ef9-f496-4149-b246-75a2514b8c99"
+    }
+  }
 }

--- a/src/api/ecom-api-context-provider.tsx
+++ b/src/api/ecom-api-context-provider.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 import { SWRConfig } from 'swr';
-import { ecomApi } from './ecom-api';
+import { getEcomApi } from './ecom-api';
 
-export type EcomAPI = typeof ecomApi;
+export type EcomAPI = ReturnType<typeof getEcomApi>;
 export type Cart = Awaited<ReturnType<EcomAPI['getCart']>>;
 
 export const EcomAPIContext = React.createContext<EcomAPI | null>(null);
@@ -26,7 +26,7 @@ export const EcomAPIContextProvider: FC<React.PropsWithChildren> = ({ children }
                 keepPreviousData: true,
             }}
         >
-            <EcomAPIContext.Provider value={ecomApi}>{children}</EcomAPIContext.Provider>
+            <EcomAPIContext.Provider value={getEcomApi()}>{children}</EcomAPIContext.Provider>
         </SWRConfig>
     );
 };

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -15,15 +15,13 @@ function getWixClientId() {
      * so we are trying to read WIX_CLIENT_ID from process.env on server side
      * or from window.ENV on client side. for client, the root loader is populating window.ENV
      */
-    let clientId: string | undefined;
-    if (typeof window !== 'undefined') {
-        clientId = window.ENV?.WIX_CLIENT_ID;
-    } else {
-        clientId = process.env?.WIX_CLIENT_ID;
-    }
+    const env =
+        typeof window !== 'undefined' && typeof window.ENV !== 'undefined'
+            ? window.ENV
+            : process.env;
 
     /* fallback to the Wix demo store id (it's not a secret). */
-    return clientId ?? '0c9d1ef9-f496-4149-b246-75a2514b8c99';
+    return env.WIX_CLIENT_ID ?? '0c9d1ef9-f496-4149-b246-75a2514b8c99';
 }
 
 function getTokensClient() {

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -43,7 +43,9 @@ function getWixClient() {
     });
 }
 
-function createEcomApi(wixClient: ReturnType<typeof getWixClient>) {
+export function getEcomApi() {
+    const wixClient = getWixClient();
+
     return {
         getAllProducts: async () => {
             return (await wixClient.products.queryProducts().find()).items;
@@ -116,5 +118,3 @@ function createEcomApi(wixClient: ReturnType<typeof getWixClient>) {
         },
     };
 }
-
-export const getEcomApi = () => createEcomApi(getWixClient());


### PR DESCRIPTION
fixes [22094](https://github.com/wixplosives/codux/issues/22094)

- fixed App component env vars population considering codux environment and limitations
- lazy ecom API creating to wait for env vars to be available
- improve `getWixClientId` to not mix between `process.env` and `window.ENV`
- add wix demo store id to codux config environment variables section so user will be able to find and replace it
- include root loader in App board
- add root loader for `PageWrapper` component, so pages now have access to env vars