### PR TITLE
Update API errors handling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,18 @@
 {
-  "printWidth": 100,
+  "printWidth": 120,
   "singleQuote": true,
   "overrides": [
     {
-      "files": ["*.js", "*.cjs", "*.mjs", "*.ts", "*.tsx", "*.cts", "*.mts", "*.scss"],
+      "files": [
+        "*.js",
+        "*.cjs",
+        "*.mjs",
+        "*.ts",
+        "*.tsx",
+        "*.cts",
+        "*.mts",
+        "*.scss"
+      ],
       "options": {
         "tabWidth": 4
       }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,6 +17,7 @@ import { ErrorComponent } from '~/components/error-component/error-component';
 import { SiteWrapper } from '~/components/site-wrapper/site-wrapper';
 import { ROUTES } from '~/router/config';
 import '~/styles/index.scss';
+import { toError } from '~/utils';
 
 export async function loader() {
     return json({
@@ -59,9 +60,7 @@ export default function App() {
 }
 
 export function ErrorBoundary() {
-    const locationRef = useRef<string | undefined>(
-        typeof window !== 'undefined' ? window.location.href : undefined
-    );
+    const locationRef = useRef<string | undefined>(typeof window !== 'undefined' ? window.location.href : undefined);
 
     const error = useRouteError();
 
@@ -101,27 +100,4 @@ function ContentWrapper({ children }: React.PropsWithChildren) {
             </CartOpenContextProvider>
         </EcomAPIContextProvider>
     );
-}
-
-function toError(value: unknown): Error {
-    if (value instanceof Error) {
-        return value;
-    }
-
-    if (typeof value === 'undefined') {
-        return new Error();
-    }
-
-    let errorMessage = String(value);
-    if (typeof value === 'object' && value !== null) {
-        if ('message' in value) {
-            errorMessage = String(value.message);
-        }
-
-        if ('data' in value) {
-            errorMessage = String(value.data);
-        }
-    }
-
-    return new Error(errorMessage);
 }

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,5 +1,5 @@
 import { LinksFunction, LoaderFunctionArgs } from '@remix-run/node';
-import { Link, MetaFunction, useLoaderData, useNavigate } from '@remix-run/react';
+import { Link, MetaFunction, useLoaderData, useNavigate, json } from '@remix-run/react';
 import { getEcomApi } from '~/api/ecom-api';
 import { HeroImage } from '~/components/hero-image/hero-image';
 import { ProductCard } from '~/components/product-card/product-card';
@@ -8,10 +8,12 @@ import { getUrlOriginWithPath } from '~/utils';
 import styles from './index.module.scss';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-    const products = await getEcomApi().getPromotedProducts();
-    const canonicalUrl = getUrlOriginWithPath(request.url);
+    const productsResponse = await getEcomApi().getPromotedProducts();
+    if (productsResponse.status === 'failure') {
+        throw json(productsResponse.error);
+    }
 
-    return { products, canonicalUrl };
+    return { products: productsResponse.body, canonicalUrl: getUrlOriginWithPath(request.url) };
 };
 
 export default function HomePage() {

--- a/app/routes/category.$categorySlug/route.tsx
+++ b/app/routes/category.$categorySlug/route.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { LinksFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { NavLink, useLoaderData } from '@remix-run/react';
+import { NavLink, useLoaderData, json, useRouteError, useNavigate, isRouteErrorResponse } from '@remix-run/react';
 import { getEcomApi } from '~/api/ecom-api';
 import { getImageHttpUrl } from '~/api/wix-image';
 import { ProductCard } from '~/components/product-card/product-card';
@@ -8,6 +8,8 @@ import { ROUTES } from '~/router/config';
 import commonStyles from '~/styles/common-styles.module.scss';
 import { getUrlOriginWithPath } from '~/utils';
 import styles from './category.module.scss';
+import { EcomApiErrorCodes } from '~/api/types';
+import { ErrorComponent } from '~/components/error-component/error-component';
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     const categorySlug = params.categorySlug;
@@ -16,14 +18,24 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     }
 
     const api = getEcomApi();
-    const currentCategory = await api.getCategoryBySlug(categorySlug);
-    const allCategories = await api.getAllCategories();
-    const categoryProducts = await api.getProductsByCategory(categorySlug);
+    const currentCategoryResponse = await api.getCategoryBySlug(categorySlug);
+    if (currentCategoryResponse.status === 'failure') {
+        throw json(currentCategoryResponse.error);
+    }
+    const allCategoriesResponse = await api.getAllCategories();
+    if (allCategoriesResponse.status === 'failure') {
+        throw json(allCategoriesResponse.error);
+    }
+
+    const categoryProductsResponse = await api.getProductsByCategory(categorySlug);
+    if (categoryProductsResponse.status === 'failure') {
+        throw json(categoryProductsResponse.error);
+    }
 
     return {
-        categoryProducts,
-        currentCategory,
-        allCategories,
+        categoryProducts: categoryProductsResponse.body,
+        currentCategory: currentCategoryResponse.body,
+        allCategories: allCategoriesResponse.body,
         canonicalUrl: getUrlOriginWithPath(request.url),
     };
 };
@@ -66,10 +78,7 @@ export default function ProductsCategoryPage() {
                             item.name && (
                                 <NavLink to={ROUTES.product.to(item.slug)} key={item.slug}>
                                     <ProductCard
-                                        imageUrl={getImageHttpUrl(
-                                            item.media?.items?.at(0)?.image?.url,
-                                            240
-                                        )}
+                                        imageUrl={getImageHttpUrl(item.media?.items?.at(0)?.image?.url, 240)}
                                         name={item.name}
                                         price={item.priceData ?? undefined}
                                         className={styles.productCard}
@@ -81,6 +90,34 @@ export default function ProductsCategoryPage() {
             </div>
         </div>
     );
+}
+
+export function ErrorBoundary() {
+    const error = useRouteError();
+    const navigate = useNavigate();
+
+    if (isRouteErrorResponse(error)) {
+        let title: string;
+        let message: string | undefined;
+        if (error.data.code === EcomApiErrorCodes.CategoryNotFound) {
+            title = 'Category Not Found';
+            message = "Unfortunately category you trying to open doesn't exist";
+        } else {
+            title = 'Failed to load category products';
+            message = error.data.message;
+        }
+
+        return (
+            <ErrorComponent
+                title={title}
+                message={message}
+                actionButtonText="Back to shopping"
+                onActionButtonClick={() => navigate(ROUTES.category.to())}
+            />
+        );
+    }
+
+    throw error;
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -6,14 +6,28 @@ import { useEcomAPI } from './ecom-api-context-provider';
 
 export const useCart = () => {
     const ecomApi = useEcomAPI();
-    return useSwr('cart', ecomApi.getCart);
+    return useSwr('cart', async () => {
+        const cartResponse = await ecomApi.getCart();
+        if (cartResponse.status === 'failure') {
+            throw cartResponse.error;
+        }
+
+        return cartResponse.body;
+    });
 };
 
 export const useCartTotals = () => {
     const ecomApi = useEcomAPI();
     const { data } = useCart();
 
-    const cartTotals = useSwr('cart-totals', ecomApi.getCartTotals);
+    const cartTotals = useSwr('cart-totals', async () => {
+        const cartTotalsResponse = await ecomApi.getCartTotals();
+        if (cartTotalsResponse.status === 'failure') {
+            throw cartTotalsResponse.error;
+        }
+
+        return cartTotalsResponse.body;
+    });
 
     useEffect(() => {
         cartTotals.mutate();
@@ -36,10 +50,7 @@ export const useAddToCart = () => {
             }
             const itemInCart = findItemIdInCart(cart, arg.id, arg.options);
             return itemInCart
-                ? ecomApi.updateCartItemQuantity(
-                      itemInCart._id,
-                      (itemInCart.quantity || 0) + arg.quantity
-                  )
+                ? ecomApi.updateCartItemQuantity(itemInCart._id, (itemInCart.quantity || 0) + arg.quantity)
                 : ecomApi.addToCart(arg.id, arg.quantity, arg.options);
         },
         {
@@ -63,12 +74,8 @@ export const useUpdateCartItemQuantity = () => {
 
 export const useRemoveItemFromCart = () => {
     const ecomApi = useEcomAPI();
-    return useSWRMutation(
-        'cart',
-        (_key: Key, { arg }: { arg: string }) => ecomApi.removeItemFromCart(arg),
-        {
-            revalidate: false,
-            populateCache: true,
-        }
-    );
+    return useSWRMutation('cart', (_key: Key, { arg }: { arg: string }) => ecomApi.removeItemFromCart(arg), {
+        revalidate: false,
+        populateCache: true,
+    });
 };

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -50,7 +50,7 @@ export const useAddToCart = () => {
             }
             const itemInCart = findItemIdInCart(cart, arg.id, arg.options);
             return itemInCart
-                ? ecomApi.updateCartItemQuantity(itemInCart._id, (itemInCart.quantity || 0) + arg.quantity)
+                ? ecomApi.updateCartItemQuantity(itemInCart._id, (itemInCart.quantity ?? 0) + arg.quantity)
                 : ecomApi.addToCart(arg.id, arg.quantity, arg.options);
         },
         {

--- a/src/api/ecom-api-context-provider.tsx
+++ b/src/api/ecom-api-context-provider.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { SWRConfig } from 'swr';
-import { type EcomAPI, getEcomApi } from './ecom-api';
+import { getEcomApi } from './ecom-api';
+import { EcomAPI } from './types';
 
 export const EcomAPIContext = React.createContext<EcomAPI | null>(null);
 

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -4,11 +4,7 @@ import { OAuthStrategy, createClient } from '@wix/sdk';
 import { products, collections } from '@wix/stores';
 import Cookies from 'js-cookie';
 import { ROUTES } from '~/router/config';
-import {
-    DEMO_STORE_WIX_CLIENT_ID,
-    WIX_SESSION_TOKEN_COOKIE_KEY,
-    WIX_STORES_APP_ID,
-} from './constants';
+import { DEMO_STORE_WIX_CLIENT_ID, WIX_SESSION_TOKEN_COOKIE_KEY, WIX_STORES_APP_ID } from './constants';
 
 function getWixClientId() {
     /**
@@ -17,11 +13,7 @@ function getWixClientId() {
      * or from window.ENV (created by the root loader) on client side.
      */
     const env =
-        typeof window !== 'undefined' && window.ENV
-            ? window.ENV
-            : typeof process !== 'undefined'
-            ? process.env
-            : {};
+        typeof window !== 'undefined' && window.ENV ? window.ENV : typeof process !== 'undefined' ? process.env : {};
 
     return env.WIX_CLIENT_ID ?? DEMO_STORE_WIX_CLIENT_ID;
 }
@@ -47,68 +39,117 @@ function getWixClient() {
     });
 }
 
-function createApi() {
+function createApi(): EcomAPI {
     const wixClient = getWixClient();
 
     return {
-        getProductsByCategory: async (categorySlug: string) => {
-            const getCategoryResult = await wixClient.collections.getCollectionBySlug(categorySlug);
-
-            return (
-                await wixClient.products
+        async getProductsByCategory(categorySlug) {
+            try {
+                const category = (await wixClient.collections.getCollectionBySlug(categorySlug)).collection;
+                if (!category) {
+                    throw new Error('Category not found');
+                }
+                const productsResponse = await wixClient.products
                     .queryProducts()
-                    .hasSome('collectionIds', [getCategoryResult.collection?._id])
-                    .find()
-            ).items;
+                    .hasSome('collectionIds', [category!._id])
+                    .find();
+                return successResponse(productsResponse.items);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
+            }
         },
-        getPromotedProducts: async () => {
-            return (await wixClient.products.queryProducts().limit(4).find()).items;
+
+        async getPromotedProducts() {
+            try {
+                const products = (await wixClient.products.queryProducts().limit(4).find()).items;
+                return successResponse(products);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
+            }
         },
-        getProduct: async (slug: string | undefined) => {
-            return slug
-                ? (await wixClient.products.queryProducts().eq('slug', slug).limit(1).find())
-                      .items[0]
-                : undefined;
+        async getProductBySlug(slug) {
+            try {
+                const product = (await wixClient.products.queryProducts().eq('slug', slug).limit(1).find()).items[0];
+                if (product === undefined) {
+                    return failureResponse(EcomApiErrorCodes.ProductNotFound);
+                }
+                return successResponse(product);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetProductFailure, getErrorMessage(e));
+            }
         },
-        getCart: () => {
-            return wixClient.currentCart.getCurrentCart();
+        async getCart() {
+            try {
+                const currentCart = await wixClient.currentCart.getCurrentCart();
+                return successResponse(currentCart);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e));
+            }
         },
-        getCartTotals: () => {
-            return wixClient.currentCart.estimateCurrentCartTotals();
+        async getCartTotals() {
+            try {
+                const cartTotals = await wixClient.currentCart.estimateCurrentCartTotals();
+                return successResponse(cartTotals);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e));
+            }
         },
-        updateCartItemQuantity: async (id: string | undefined | null, quantity: number) => {
-            const result = await wixClient.currentCart.updateCurrentCartLineItemQuantity([
-                {
-                    _id: id || undefined,
-                    quantity,
-                },
-            ]);
-            return result.cart;
-        },
-        removeItemFromCart: async (id: string) => {
-            const result = await wixClient.currentCart.removeLineItemsFromCurrentCart([id]);
-            return result.cart;
-        },
-        addToCart: async (id: string, quantity: number, options?: Record<string, string>) => {
-            const result = await wixClient.currentCart.addToCurrentCart({
-                lineItems: [
+        async updateCartItemQuantity(id, quantity) {
+            try {
+                const result = await wixClient.currentCart.updateCurrentCartLineItemQuantity([
                     {
-                        catalogReference: {
-                            catalogItemId: id,
-                            appId: WIX_STORES_APP_ID,
-                            options: { options: options },
-                        },
-                        quantity: quantity,
+                        _id: id || undefined,
+                        quantity,
                     },
-                ],
-            });
-            const tokens = wixClient.auth.getTokens();
-            Cookies.set(WIX_SESSION_TOKEN_COOKIE_KEY, JSON.stringify(tokens));
+                ]);
+                if (!result.cart) {
+                    throw new Error('Failed to update cart item quantity');
+                }
+                return successResponse(result.cart);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.UpdateCartItemQuantityFailure, getErrorMessage(e));
+            }
+        },
+        async removeItemFromCart(id) {
+            try {
+                const result = await wixClient.currentCart.removeLineItemsFromCurrentCart([id]);
+                if (!result.cart) {
+                    throw new Error('Failed to remove cart item');
+                }
+                return successResponse(result.cart);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e));
+            }
+        },
+        async addToCart(id, quantity, options) {
+            try {
+                const result = await wixClient.currentCart.addToCurrentCart({
+                    lineItems: [
+                        {
+                            catalogReference: {
+                                catalogItemId: id,
+                                appId: WIX_STORES_APP_ID,
+                                options: { options: options },
+                            },
+                            quantity: quantity,
+                        },
+                    ],
+                });
 
-            return result.cart;
+                if (!result.cart) {
+                    throw new Error('Failed to add item to cart');
+                }
+
+                const tokens = wixClient.auth.getTokens();
+                Cookies.set(WIX_SESSION_TOKEN_COOKIE_KEY, JSON.stringify(tokens));
+
+                return successResponse(result.cart);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.AddCartItemFailure);
+            }
         },
 
-        checkout: async () => {
+        async checkout() {
             let checkoutId;
             try {
                 const result = await wixClient.currentCart.createCheckoutFromCurrentCart({
@@ -116,30 +157,66 @@ function createApi() {
                 });
                 checkoutId = result.checkoutId;
             } catch (e) {
-                return { success: false, url: '' };
+                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e));
             }
-            const { redirectSession } = await wixClient.redirects.createRedirectSession({
-                ecomCheckout: { checkoutId },
-                callbacks: {
-                    postFlowUrl: window.location.origin,
-                    thankYouPageUrl: `${window.location.origin}${ROUTES.thankYou.path}`,
-                },
-            });
-            return { success: true, url: redirectSession?.fullUrl };
+
+            try {
+                const { redirectSession } = await wixClient.redirects.createRedirectSession({
+                    ecomCheckout: { checkoutId },
+                    callbacks: {
+                        postFlowUrl: window.location.origin,
+                        thankYouPageUrl: `${window.location.origin}${ROUTES.thankYou.path}`,
+                    },
+                });
+                if (!redirectSession?.fullUrl) {
+                    throw new Error('Missing redirect session url');
+                }
+                return successResponse({ checkoutUrl: redirectSession?.fullUrl });
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure, getErrorMessage(e));
+            }
         },
-        getAllCategories: async () => {
-            return (await wixClient.collections.queryCollections().find()).items;
+        async getAllCategories() {
+            try {
+                const categories = (await wixClient.collections.queryCollections().find()).items;
+                return successResponse(categories);
+            } catch (e) {
+                return failureResponse(EcomApiErrorCodes.GetAllCategoriesFailure);
+            }
         },
-        getCategoryBySlug: async (slug: string) => {
-            return (await wixClient.collections.getCollectionBySlug(slug)).collection;
+        async getCategoryBySlug(slug) {
+            try {
+                const category = (await wixClient.collections.getCollectionBySlug(slug)).collection;
+                if (!category) {
+                    return failureResponse(EcomApiErrorCodes.CategoryNotFound);
+                }
+
+                return successResponse(category);
+            } catch (e) {
+                if (isEcomAPIError(e) && e.details.applicationError.code === 404) {
+                    return failureResponse(EcomApiErrorCodes.CategoryNotFound);
+                }
+
+                return failureResponse(EcomApiErrorCodes.GetCategoryFailure, getErrorMessage(e));
+            }
         },
-        getOrder: async (id: string) => {
-            return await wixClient.orders.getOrder(id);
+        async getOrder(id) {
+            try {
+                const order = await wixClient.orders.getOrder(id);
+                if (!order) {
+                    return failureResponse(EcomApiErrorCodes.OrderNotFound);
+                }
+
+                return successResponse(order);
+            } catch (e) {
+                if (isEcomAPIError(e) && e.details.applicationError.code === 404) {
+                    return failureResponse(EcomApiErrorCodes.OrderNotFound);
+                }
+                return failureResponse(EcomApiErrorCodes.GetOrderFailure);
+            }
         },
     };
 }
-
-export type EcomAPI = ReturnType<typeof createApi>;
 
 let api: EcomAPI | undefined;
 export function getEcomApi() {
@@ -148,4 +225,22 @@ export function getEcomApi() {
     }
 
     return api;
+}
+
+function failureResponse(code: EcomApiErrorCodes, message?: string): EcomAPIFailureResponse {
+    return {
+        status: 'failure',
+        error: { code, message },
+    };
+}
+
+function successResponse<T>(body: T): EcomAPISuccessResponse<T> {
+    return {
+        status: 'success',
+        body,
+    };
+}
+
+function getErrorMessage(e: unknown, defaultMessage?: string) {
+    return isEcomAPIError(e) ? e.message : defaultMessage;
 }

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -4,7 +4,9 @@ import { OAuthStrategy, createClient } from '@wix/sdk';
 import { products, collections } from '@wix/stores';
 import Cookies from 'js-cookie';
 import { ROUTES } from '~/router/config';
+import { toError } from '~/utils';
 import { DEMO_STORE_WIX_CLIENT_ID, WIX_SESSION_TOKEN_COOKIE_KEY, WIX_STORES_APP_ID } from './constants';
+import { EcomApiErrorCodes, EcomAPIFailureResponse, EcomAPISuccessResponse, isEcomAPIError, EcomAPI } from './types';
 
 function getWixClientId() {
     /**
@@ -241,6 +243,6 @@ function successResponse<T>(body: T): EcomAPISuccessResponse<T> {
     };
 }
 
-function getErrorMessage(e: unknown, defaultMessage?: string) {
-    return isEcomAPIError(e) ? e.message : defaultMessage;
+function getErrorMessage(e: unknown): string {
+    return isEcomAPIError(e) ? e.message : toError(e).message;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,67 @@
+import { collections, products } from '@wix/stores';
+import { currentCart, orders } from '@wix/ecom';
+
+export type Product = products.Product;
+export type Collection = collections.Collection;
+export type CollectionDetails = collections.Collection & collections.CollectionNonNullableFields;
+export type Cart = currentCart.Cart & currentCart.CartNonNullableFields;
+export type CartTotals = currentCart.EstimateTotalsResponse & currentCart.EstimateTotalsResponseNonNullableFields;
+export type OrderDetails = orders.Order & orders.OrderNonNullableFields;
+
+export enum EcomApiErrorCodes {
+    ProductNotFound = 'ProductNotFound',
+    GetProductFailure = 'GetProductFailure',
+    GetProductsFailure = 'GetProductsFailure',
+    CategoryNotFound = 'CategoryNotFound',
+    GetCategoryFailure = 'GetCategoryFailure',
+    GetAllCategoriesFailure = 'GetAllCategoriesFailure',
+    GetCartFailure = 'GetCartFailure',
+    GetCartTotalsFailure = 'GetCartTotalsFailure',
+    UpdateCartItemQuantityFailure = 'UpdateCartItemQuantityFailure',
+    RemoveCartItemFailure = 'RemoveCartItemFailure',
+    AddCartItemFailure = 'AddCartItemFailure',
+    CreateCheckoutFailure = 'CreateCheckoutFailure',
+    CreateCheckoutRedirectSessionFailure = 'CreateCheckoutRedirectSessionFailure',
+    OrderNotFound = 'OrderNotFound',
+    GetOrderFailure = 'GetOrderFailure',
+}
+
+export type EcomAPISuccessResponse<T> = { status: 'success'; body: T };
+export type EcomAPIFailureResponse = { status: 'failure'; error: { code: EcomApiErrorCodes; message?: string } };
+export type EcomAPIResponse<T> = EcomAPISuccessResponse<T> | EcomAPIFailureResponse;
+
+export type EcomAPIError = {
+    message: string;
+    details: {
+        applicationError: {
+            description: string;
+            code: number;
+        };
+    };
+};
+
+export function isEcomAPIError(error: unknown): error is EcomAPIError {
+    return (
+        error instanceof Object &&
+        'message' in error &&
+        'details' in error &&
+        error.details instanceof Object &&
+        'applicationError' in error.details &&
+        error.details.applicationError instanceof Object
+    );
+}
+
+export type EcomAPI = {
+    getProductsByCategory: (categorySlug: string) => Promise<EcomAPIResponse<Product[]>>;
+    getPromotedProducts: () => Promise<EcomAPIResponse<Product[]>>;
+    getProductBySlug: (slug: string) => Promise<EcomAPIResponse<Product>>;
+    getCart: () => Promise<EcomAPIResponse<Cart>>;
+    getCartTotals: () => Promise<EcomAPIResponse<CartTotals>>;
+    updateCartItemQuantity: (id: string | undefined | null, quantity: number) => Promise<EcomAPIResponse<Cart>>;
+    removeItemFromCart: (id: string) => Promise<EcomAPIResponse<Cart>>;
+    addToCart: (id: string, quantity: number, options?: Record<string, string>) => Promise<EcomAPIResponse<Cart>>;
+    checkout: () => Promise<EcomAPIResponse<{ checkoutUrl: string }>>;
+    getAllCategories: () => Promise<EcomAPIResponse<Collection[]>>;
+    getCategoryBySlug: (slug: string) => Promise<EcomAPIResponse<CollectionDetails>>;
+    getOrder: (id: string) => Promise<EcomAPIResponse<OrderDetails>>;
+};

--- a/src/components/cart/cart.tsx
+++ b/src/components/cart/cart.tsx
@@ -15,15 +15,16 @@ export const Cart = ({ className }: CartProps) => {
     const { isOpen, setIsOpen } = useCartOpen();
     const { data: cart } = useCart();
     const { data: cartTotals } = useCartTotals();
-    const isEmpty = !cart?.lineItems || cart.lineItems.length === 0;
-
     const ecomAPI = useEcomAPI();
 
+    const isEmpty = !cart?.lineItems || cart.lineItems.length === 0;
+
     async function checkout() {
-        const { success, url } = await ecomAPI.checkout();
-        if (success && url) {
-            window.location.href = url;
-        } else if (!success) {
+        const checkoutResponse = await ecomAPI.checkout();
+
+        if (checkoutResponse.status === 'success') {
+            window.location.href = checkoutResponse.body.checkoutUrl;
+        } else {
             alert('checkout is not configured');
         }
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,26 @@ export function getUrlOriginWithPath(url: string) {
     const { origin, pathname } = new URL(url);
     return new URL(pathname, origin).toString();
 }
+
+export function toError(value: unknown): Error {
+    if (value instanceof Error) {
+        return value;
+    }
+
+    if (typeof value === 'undefined') {
+        return new Error();
+    }
+
+    let errorMessage = String(value);
+    if (typeof value === 'object' && value !== null) {
+        if ('message' in value) {
+            errorMessage = String(value.message);
+        }
+
+        if ('data' in value) {
+            errorMessage = String(value.data);
+        }
+    }
+
+    return new Error(errorMessage);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,20 +8,19 @@ export function toError(value: unknown): Error {
         return value;
     }
 
-    if (typeof value === 'undefined') {
+    if (typeof value === 'undefined' || value === null) {
         return new Error();
     }
 
-    let errorMessage = String(value);
-    if (typeof value === 'object' && value !== null) {
+    if (typeof value === 'object') {
         if ('message' in value) {
-            errorMessage = String(value.message);
+            throw new Error(String(value.message));
         }
 
         if ('data' in value) {
-            errorMessage = String(value.data);
+            throw new Error(String(value.data));
         }
     }
 
-    return new Error(errorMessage);
+    return new Error(String(value));
 }


### PR DESCRIPTION
Fixes https://github.com/wixplosives/codux/issues/22381

- Changed `EcomAPI` methods to return `EcomAPIResponse` type, which simplifies error handling on the client
```
type EcomAPISuccessResponse<T> = { status: 'success'; body: T };
type EcomAPIFailureResponse = { status: 'failure'; error: { code: EcomApiErrorCodes; message?: string } };
type EcomAPIResponse<T> = EcomAPISuccessResponse<T> | EcomAPIFailureResponse;
```

- Added ErrorBoundary to the category page

- Increase prettier  "printWidth" from 100 to 120