### PR TITLE
fix: fixed env vars reading from process.env

### DIFF
--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -15,7 +15,12 @@ function getWixClientId() {
      * so we are trying to read WIX_CLIENT_ID from process.env on server side
      * or from window.ENV on client side. for client, the root loader is populating window.ENV
      */
-    const env = typeof window !== 'undefined' ? window.ENV ?? {} : process.env;
+    const env =
+        typeof window !== 'undefined' && window.ENV
+            ? window.ENV
+            : typeof process !== 'undefined'
+            ? process.env
+            : {};
 
     /* fallback to the Wix demo store id (it's not a secret). */
     return env.WIX_CLIENT_ID ?? '0c9d1ef9-f496-4149-b246-75a2514b8c99';


### PR DESCRIPTION
in codux, components are rendered on browser env, so there is window object defined. however, window.env is empty, cause codux passes env vars via process.env