### PR TITLE
refactor: rename toError function, add comment

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,7 @@ import { ErrorComponent } from '~/components/error-component/error-component';
 import { SiteWrapper } from '~/components/site-wrapper/site-wrapper';
 import { ROUTES } from '~/router/config';
 import '~/styles/index.scss';
-import { toError } from '~/utils';
+import { getErrorMessage } from '~/utils';
 
 export async function loader() {
     return json({
@@ -84,7 +84,7 @@ export function ErrorBoundary() {
         <ContentWrapper>
             <ErrorComponent
                 title={isPageNotFoundError ? 'Page Not Found' : 'Oops, something went wrong'}
-                message={isPageNotFoundError ? undefined : toError(error).message}
+                message={isPageNotFoundError ? undefined : getErrorMessage(error)}
                 actionButtonText="Back to shopping"
                 onActionButtonClick={() => navigate(ROUTES.category.to())}
             />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -84,7 +84,7 @@ export function ErrorBoundary() {
         <ContentWrapper>
             <ErrorComponent
                 title={isPageNotFoundError ? 'Page Not Found' : 'Oops, something went wrong'}
-                message={isPageNotFoundError ? undefined : getErrorMessage(error) ?? 'Unknown error'}
+                message={isPageNotFoundError ? undefined : getErrorMessage(error)}
                 actionButtonText="Back to shopping"
                 onActionButtonClick={() => navigate(ROUTES.category.to())}
             />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -84,7 +84,7 @@ export function ErrorBoundary() {
         <ContentWrapper>
             <ErrorComponent
                 title={isPageNotFoundError ? 'Page Not Found' : 'Oops, something went wrong'}
-                message={isPageNotFoundError ? undefined : getErrorMessage(error)}
+                message={isPageNotFoundError ? undefined : getErrorMessage(error) ?? 'Unknown error'}
                 actionButtonText="Back to shopping"
                 onActionButtonClick={() => navigate(ROUTES.category.to())}
             />

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -1,12 +1,12 @@
 import { currentCart, orders } from '@wix/ecom';
 import { redirects } from '@wix/redirects';
-import { OAuthStrategy, createClient } from '@wix/sdk';
-import { products, collections } from '@wix/stores';
+import { createClient, OAuthStrategy } from '@wix/sdk';
+import { collections, products } from '@wix/stores';
 import Cookies from 'js-cookie';
 import { ROUTES } from '~/router/config';
-import { toError } from '~/utils';
+import { getErrorMessage } from '~/utils';
 import { DEMO_STORE_WIX_CLIENT_ID, WIX_SESSION_TOKEN_COOKIE_KEY, WIX_STORES_APP_ID } from './constants';
-import { EcomApiErrorCodes, EcomAPIFailureResponse, EcomAPISuccessResponse, isEcomSDKError, EcomAPI } from './types';
+import { EcomAPI, EcomApiErrorCodes, EcomAPIFailureResponse, EcomAPISuccessResponse, isEcomSDKError } from './types';
 
 function getWixClientId() {
     /**
@@ -252,8 +252,4 @@ function successResponse<T>(body: T): EcomAPISuccessResponse<T> {
         status: 'success',
         body,
     };
-}
-
-function getErrorMessage(e: unknown): string {
-    return isEcomSDKError(e) ? e.message : toError(e).message;
 }

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -68,7 +68,7 @@ function createApi(): EcomAPI {
 
                 return successResponse(allProducts);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
             }
         },
 
@@ -77,7 +77,7 @@ function createApi(): EcomAPI {
                 const products = (await wixClient.products.queryProducts().limit(4).find()).items;
                 return successResponse(products);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
             }
         },
         async getProductBySlug(slug) {
@@ -88,7 +88,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(product);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetProductFailure, getErrorMessage(e));
             }
         },
         async getCart() {
@@ -96,7 +96,7 @@ function createApi(): EcomAPI {
                 const currentCart = await wixClient.currentCart.getCurrentCart();
                 return successResponse(currentCart);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e));
             }
         },
         async getCartTotals() {
@@ -104,7 +104,7 @@ function createApi(): EcomAPI {
                 const cartTotals = await wixClient.currentCart.estimateCurrentCartTotals();
                 return successResponse(cartTotals);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e));
             }
         },
         async updateCartItemQuantity(id, quantity) {
@@ -120,10 +120,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(result.cart);
             } catch (e) {
-                return failureResponse(
-                    EcomApiErrorCodes.UpdateCartItemQuantityFailure,
-                    getErrorMessage(e) ?? 'Unknown error'
-                );
+                return failureResponse(EcomApiErrorCodes.UpdateCartItemQuantityFailure, getErrorMessage(e));
             }
         },
         async removeItemFromCart(id) {
@@ -134,7 +131,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(result.cart);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e));
             }
         },
         async addToCart(id, quantity, options) {
@@ -173,7 +170,7 @@ function createApi(): EcomAPI {
                 });
                 checkoutId = result.checkoutId;
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e));
             }
 
             try {
@@ -189,10 +186,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse({ checkoutUrl: redirectSession?.fullUrl });
             } catch (e) {
-                return failureResponse(
-                    EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure,
-                    getErrorMessage(e) ?? 'Unknown error'
-                );
+                return failureResponse(EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure, getErrorMessage(e));
             }
         },
         async getAllCategories() {
@@ -216,7 +210,7 @@ function createApi(): EcomAPI {
                     return failureResponse(EcomApiErrorCodes.CategoryNotFound);
                 }
 
-                return failureResponse(EcomApiErrorCodes.GetCategoryFailure, getErrorMessage(e) ?? 'Unknown error');
+                return failureResponse(EcomApiErrorCodes.GetCategoryFailure, getErrorMessage(e));
             }
         },
         async getOrder(id) {

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -68,7 +68,7 @@ function createApi(): EcomAPI {
 
                 return successResponse(allProducts);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
 
@@ -77,7 +77,7 @@ function createApi(): EcomAPI {
                 const products = (await wixClient.products.queryProducts().limit(4).find()).items;
                 return successResponse(products);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetProductsFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async getProductBySlug(slug) {
@@ -88,7 +88,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(product);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetProductFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetProductFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async getCart() {
@@ -96,7 +96,7 @@ function createApi(): EcomAPI {
                 const currentCart = await wixClient.currentCart.getCurrentCart();
                 return successResponse(currentCart);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetCartFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async getCartTotals() {
@@ -104,7 +104,7 @@ function createApi(): EcomAPI {
                 const cartTotals = await wixClient.currentCart.estimateCurrentCartTotals();
                 return successResponse(cartTotals);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetCartTotalsFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async updateCartItemQuantity(id, quantity) {
@@ -120,7 +120,10 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(result.cart);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.UpdateCartItemQuantityFailure, getErrorMessage(e));
+                return failureResponse(
+                    EcomApiErrorCodes.UpdateCartItemQuantityFailure,
+                    getErrorMessage(e) ?? 'Unknown error'
+                );
             }
         },
         async removeItemFromCart(id) {
@@ -131,7 +134,7 @@ function createApi(): EcomAPI {
                 }
                 return successResponse(result.cart);
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.RemoveCartItemFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async addToCart(id, quantity, options) {
@@ -170,7 +173,7 @@ function createApi(): EcomAPI {
                 });
                 checkoutId = result.checkoutId;
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.CreateCheckoutFailure, getErrorMessage(e) ?? 'Unknown error');
             }
 
             try {
@@ -186,7 +189,10 @@ function createApi(): EcomAPI {
                 }
                 return successResponse({ checkoutUrl: redirectSession?.fullUrl });
             } catch (e) {
-                return failureResponse(EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure, getErrorMessage(e));
+                return failureResponse(
+                    EcomApiErrorCodes.CreateCheckoutRedirectSessionFailure,
+                    getErrorMessage(e) ?? 'Unknown error'
+                );
             }
         },
         async getAllCategories() {
@@ -210,7 +216,7 @@ function createApi(): EcomAPI {
                     return failureResponse(EcomApiErrorCodes.CategoryNotFound);
                 }
 
-                return failureResponse(EcomApiErrorCodes.GetCategoryFailure, getErrorMessage(e));
+                return failureResponse(EcomApiErrorCodes.GetCategoryFailure, getErrorMessage(e) ?? 'Unknown error');
             }
         },
         async getOrder(id) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -18,7 +18,7 @@ export function getErrorMessage(value: unknown): string {
     }
 
     if (isRouteErrorResponse(value)) {
-        return value.data instanceof Error ? value.data.message : String(value.data);
+        return value.data;
     }
 
     if (isEcomSDKError(value)) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,7 +7,7 @@ export function getUrlOriginWithPath(url: string) {
 }
 
 /**
- * Try to find some error message in unknown value
+ * Try to find some error message in unknown value.
  *
  * Handles cases when value is `ErrorResponse`, `EcomSDKError`, `String` or `Object`.
  *

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -8,9 +8,11 @@ export function getUrlOriginWithPath(url: string) {
 
 /*
  * Retrieves the message from a thrown error.
- * - Handles Remix ErrorResponse (non-Error instances).
- * - Handles Wix eCom SDK errors (non-Error instances).
- * - Defaults to converting the value to a string if no specific error type is matched.
+ * - Handles Remix ErrorResponse (non-Error instance).
+ * - Handles Wix eCom SDK errors (non-Error instance).
+ * - Converts plain objects to a JSON string as a measure
+ *   to help identify the origin of such improper errors.
+ * - Falls back on converting the value to a string.
  */
 export function getErrorMessage(value: unknown): string {
     if (value instanceof Error) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -25,5 +25,9 @@ export function getErrorMessage(value: unknown): string {
         return value.message;
     }
 
+    if (typeof value == 'object' && value !== null) {
+        return JSON.stringify(value);
+    }
+
     return String(value);
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -13,7 +13,7 @@ export function getUrlOriginWithPath(url: string) {
  */
 export function getErrorMessage(value: unknown): string | undefined {
     if (isRouteErrorResponse(value)) {
-        return String(value.data);
+        return value.data instanceof Error ? value.data.message : String(value.data);
     }
 
     if (value instanceof Error || isEcomSDKError(value)) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -9,11 +9,9 @@ export function getUrlOriginWithPath(url: string) {
 /**
  * Try to find some error message in unknown value.
  *
- * Handles cases when value is `ErrorResponse`, `EcomSDKError`, `String` or `Object`.
- *
- * Falls back to 'Unknown error' message.
+ * Handles remix ErrorResponse and wix ecom platform EcomSDKError error types.
  */
-export function getErrorMessage(value: unknown): string {
+export function getErrorMessage(value: unknown): string | undefined {
     if (isRouteErrorResponse(value)) {
         return String(value.data);
     }
@@ -30,5 +28,5 @@ export function getErrorMessage(value: unknown): string {
         return value;
     }
 
-    return 'Unknown error';
+    return undefined;
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -6,27 +6,24 @@ export function getUrlOriginWithPath(url: string) {
     return new URL(pathname, origin).toString();
 }
 
-/**
- * Try to find some error message in unknown value.
- *
- * Handles remix ErrorResponse and wix ecom platform EcomSDKError error types.
+/*
+ * Retrieves the message from a thrown error.
+ * - Handles Remix ErrorResponse (non-Error instances).
+ * - Handles Wix eCom SDK errors (non-Error instances).
+ * - Defaults to converting the value to a string if no specific error type is matched.
  */
-export function getErrorMessage(value: unknown): string | undefined {
+export function getErrorMessage(value: unknown): string {
+    if (value instanceof Error) {
+        return value.message;
+    }
+
     if (isRouteErrorResponse(value)) {
         return value.data instanceof Error ? value.data.message : String(value.data);
     }
 
-    if (value instanceof Error || isEcomSDKError(value)) {
+    if (isEcomSDKError(value)) {
         return value.message;
     }
 
-    if (typeof value === 'object' && value !== null) {
-        return JSON.stringify(value);
-    }
-
-    if (typeof value === 'string') {
-        return value;
-    }
-
-    return undefined;
+    return String(value);
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -26,7 +26,11 @@ export function getErrorMessage(value: unknown): string {
     }
 
     if (typeof value == 'object' && value !== null) {
-        return JSON.stringify(value);
+        try {
+            return JSON.stringify(value);
+        } catch {
+            // ignore serialization failure
+        }
     }
 
     return String(value);


### PR DESCRIPTION
- rename `toError` to `getErrorMessage`
- better structure code to improve readability
- add comment what it does and what cases handles