### PR TITLE
Pass variantId in addToCart call

### DIFF
--- a/app/routes/products.$productSlug/route.tsx
+++ b/app/routes/products.$productSlug/route.tsx
@@ -13,8 +13,8 @@ import { ProductOption } from '~/components/product-option/product-option';
 import { UnsafeRichText } from '~/components/rich-text/rich-text';
 import { getChoiceValue } from '~/components/product-option/product-option-utils';
 import { ROUTES } from '~/router/config';
-import { getPriceData, getUrlOriginWithPath, isOutOfStock } from '~/utils';
-import { EcomApiErrorCodes } from '~/api/types';
+import { getPriceData, getSelectedVariant, getUrlOriginWithPath, isOutOfStock } from '~/utils';
+import { AddToCartOptions, EcomApiErrorCodes } from '~/api/types';
 import commonStyles from '~/styles/common-styles.module.scss';
 import styles from './product-details.module.scss';
 
@@ -69,10 +69,17 @@ export default function ProductDetailsPage() {
         }
 
         const quantity = parseInt(quantityInput.current?.value ?? '1', 10);
+        const selectedVariant = getSelectedVariant(product, selectedOptions);
+
+        let options: AddToCartOptions = { options: selectedOptions };
+        if (product.manageVariants && selectedVariant?._id) {
+            options = { variantId: selectedVariant._id };
+        }
+
         await addToCart({
             id: product._id,
             quantity,
-            options: selectedOptions as Record<string, string>,
+            options,
         });
         setIsOpen(true);
     }

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -76,12 +76,12 @@ export const useAddToCart = () => {
     );
 };
 
-type updateCartItemQuantityArgs = { id: string; quantity: number };
+type UpdateCartItemQuantityArgs = { id: string; quantity: number };
 export const useUpdateCartItemQuantity = () => {
     const ecomApi = useEcomAPI();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: updateCartItemQuantityArgs }) => {
+        async (_key: Key, { arg }: { arg: UpdateCartItemQuantityArgs }) => {
             const response = await ecomApi.updateCartItemQuantity(arg.id, arg.quantity);
             if (response.status === 'failure') {
                 throw response.error;

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -41,7 +41,7 @@ export const useCartTotals = () => {
 type AddToCartArgs = {
     id: string;
     quantity: number;
-    options: AddToCartOptions;
+    options?: AddToCartOptions;
 };
 
 export const useAddToCart = () => {

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -3,6 +3,7 @@ import useSwr, { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 import { findItemIdInCart } from './cart-helpers';
 import { useEcomAPI } from './ecom-api-context-provider';
+import { AddToCartOptions } from './types';
 
 export const useCart = () => {
     const ecomApi = useEcomAPI();
@@ -37,14 +38,18 @@ export const useCartTotals = () => {
     return cartTotals;
 };
 
-type Args = { id: string; quantity: number };
+export type AddToCartArgs = {
+    id: string;
+    quantity: number;
+    options: AddToCartOptions;
+};
 
 export const useAddToCart = () => {
     const ecomApi = useEcomAPI();
     const { data: cart } = useCart();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: Args & { options?: Record<string, string> } }) => {
+        async (_key: Key, { arg }: { arg: AddToCartArgs }) => {
             const itemInCart = cart ? findItemIdInCart(cart, arg.id, arg.options) : undefined;
 
             if (itemInCart) {
@@ -71,11 +76,12 @@ export const useAddToCart = () => {
     );
 };
 
+type updateCartItemQuantityArgs = { id: string; quantity: number };
 export const useUpdateCartItemQuantity = () => {
     const ecomApi = useEcomAPI();
     return useSWRMutation(
         'cart',
-        async (_key: Key, { arg }: { arg: Args }) => {
+        async (_key: Key, { arg }: { arg: updateCartItemQuantityArgs }) => {
             const response = await ecomApi.updateCartItemQuantity(arg.id, arg.quantity);
             if (response.status === 'failure') {
                 throw response.error;

--- a/src/api/api-hooks.ts
+++ b/src/api/api-hooks.ts
@@ -38,7 +38,7 @@ export const useCartTotals = () => {
     return cartTotals;
 };
 
-export type AddToCartArgs = {
+type AddToCartArgs = {
     id: string;
     quantity: number;
     options: AddToCartOptions;

--- a/src/api/cart-helpers.ts
+++ b/src/api/cart-helpers.ts
@@ -1,28 +1,17 @@
-import { cart } from '@wix/ecom';
+import deepEqual from 'fast-deep-equal';
+import { AddToCartOptions, Cart } from './types';
 
-export function findItemIdInCart(
-    { lineItems }: cart.Cart & cart.CartNonNullableFields,
-    catalogItemId: string,
-    options?: Record<string, string>
-) {
+export function findItemIdInCart({ lineItems }: Cart, catalogItemId: string, options: AddToCartOptions) {
     return lineItems.find((it) => {
         if (it.catalogReference?.catalogItemId !== catalogItemId) {
             return false;
         }
-        const catalogOptions = it.catalogReference?.options?.options;
-        const optionsLength = options ? Object.keys(options).length : 0;
-        const catalogOptionsLength = catalogOptions ? Object.keys(catalogOptions).length : 0;
-        if (optionsLength !== catalogOptionsLength) {
-            return false;
+
+        if ('variantId' in options) {
+            return it.catalogReference?.options?.variantId === options.variantId;
         }
-        if (!options || !catalogOptions) {
-            return true;
-        }
-        for (const optionName of Object.keys(options)) {
-            if (options[optionName] !== catalogOptions[optionName]) {
-                return false;
-            }
-        }
-        return true;
+
+        const lineItemOptions = it.catalogReference?.options?.options;
+        return deepEqual(lineItemOptions, options.options);
     });
 }

--- a/src/api/cart-helpers.ts
+++ b/src/api/cart-helpers.ts
@@ -1,17 +1,17 @@
 import deepEqual from 'fast-deep-equal';
 import { AddToCartOptions, Cart } from './types';
 
-export function findItemIdInCart({ lineItems }: Cart, catalogItemId: string, options: AddToCartOptions) {
+export function findItemIdInCart({ lineItems }: Cart, catalogItemId: string, options?: AddToCartOptions) {
     return lineItems.find((it) => {
         if (it.catalogReference?.catalogItemId !== catalogItemId) {
             return false;
         }
 
-        if ('variantId' in options) {
+        if (options && 'variantId' in options) {
             return it.catalogReference?.options?.variantId === options.variantId;
         }
 
         const lineItemOptions = it.catalogReference?.options?.options;
-        return deepEqual(lineItemOptions, options.options);
+        return deepEqual(lineItemOptions, options?.options);
     });
 }

--- a/src/api/ecom-api.tsx
+++ b/src/api/ecom-api.tsx
@@ -142,7 +142,7 @@ function createApi(): EcomAPI {
                             catalogReference: {
                                 catalogItemId: id,
                                 appId: WIX_STORES_APP_ID,
-                                options: { options: options },
+                                options,
                             },
                             quantity: quantity,
                         },

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -41,6 +41,8 @@ export type EcomSDKError = {
         };
     };
 };
+// type according to https://www.wix.com/velo/reference/wix-stores-backend/ecommerce-integration
+export type AddToCartOptions = { variantId: string } | { options: Record<string, string | undefined> };
 
 export function isEcomSDKError(error: unknown): error is EcomSDKError {
     return (
@@ -61,7 +63,7 @@ export type EcomAPI = {
     getCartTotals: () => Promise<EcomAPIResponse<CartTotals>>;
     updateCartItemQuantity: (id: string | undefined | null, quantity: number) => Promise<EcomAPIResponse<Cart>>;
     removeItemFromCart: (id: string) => Promise<EcomAPIResponse<Cart>>;
-    addToCart: (id: string, quantity: number, options?: Record<string, string>) => Promise<EcomAPIResponse<Cart>>;
+    addToCart: (id: string, quantity: number, options?: AddToCartOptions) => Promise<EcomAPIResponse<Cart>>;
     checkout: () => Promise<EcomAPIResponse<{ checkoutUrl: string }>>;
     getAllCategories: () => Promise<EcomAPIResponse<Collection[]>>;
     getCategoryBySlug: (slug: string) => Promise<EcomAPIResponse<CollectionDetails>>;


### PR DESCRIPTION
For products with managed variants (`product.manageVariants === true`) addToCard options should take `variantId` instead of `selecrtedOptions` object.

Check documentation here - https://dev.wix.com/docs/velo/api-reference/wix-stores-backend/e-commerce-integration