### PR TITLE
fix: improve error handling

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -20,7 +20,15 @@ export function getErrorMessage(value: unknown): string {
     }
 
     if (isRouteErrorResponse(value)) {
-        return value.data;
+        if (typeof value.data == 'object' && value.data !== null) {
+            try {
+                return JSON.stringify(value.data);
+            } catch {
+                // ignore serialization failure
+            }
+        }
+
+        return String(value.data);
     }
 
     if (isEcomSDKError(value)) {


### PR DESCRIPTION
we've been assuming that value.data is always string, but it's not. I just found that it might be an object in some cases, and that leads to React errors (object is not a valid React child)