### PR TITLE
Handle trackQuantity property for out of stock indication

### DIFF
--- a/src/utils/product-utils.ts
+++ b/src/utils/product-utils.ts
@@ -9,8 +9,10 @@ export function isOutOfStock(
 ): boolean {
     if (product.manageVariants) {
         const selectedVariant = getSelectedVariant(product, selectedOptions);
-        if (selectedVariant?.stock?.inStock !== undefined) {
-            return !selectedVariant?.stock?.inStock;
+        if (selectedVariant?.stock?.trackQuantity === true) {
+            return selectedVariant?.stock?.quantity === 0;
+        } else {
+            return selectedVariant?.stock?.inStock === false;
         }
     }
 


### PR DESCRIPTION
If "Track inventory" is turned on in the wix backoffice user manually specifies how many items are still in stock (instead of just selecting "In Stock"/"Out of Stock").
If 0 items is in stock for specific variant ecom API returns `inStock: true`.
This PR makes sure that if 0 items are in stock "Out of stock" indication is shown.