### PR TITLE
Fix missing SKU issue

### DIFF
--- a/app/routes/products.$productSlug/route.tsx
+++ b/app/routes/products.$productSlug/route.tsx
@@ -99,7 +99,7 @@ export default function ProductDetailsPage() {
             <div className={styles.productInfo}>
                 <div>
                     <div className={styles.productName}>{product.name}</div>
-                    {sku !== undefined && <div className={styles.sku}>SKU: {sku}</div>}
+                    {sku && <div className={styles.sku}>SKU: {sku}</div>}
                     {priceData?.formatted?.price && (
                         <Price
                             fullPrice={priceData?.formatted?.price}


### PR DESCRIPTION
SDK sometimes return empty string SDK when it's not set in the backoffice