### PR TITLE
Remove absolute positioning from the intro board

### DIFF
--- a/_codux/boards/intro/intro.board.tsx
+++ b/_codux/boards/intro/intro.board.tsx
@@ -5,17 +5,19 @@ export default createBoard({
     name: '🌱 Intro',
     Board: () => (
         <div className={styles.container}>
-            <p className={styles.myStyle}>
-                HOW TO USE <br /> E-COMMERCE STARTER?
-            </p>
-            <p className={styles.myParagraph}>
-                Welcome to Codux e-commerce starter. <br /> This template was built to help you create your own store
-                easily. Use Codux to design your website the way you want, and Wix Headless e-commerce services to
-                manage your store.
-                <a href={'https://help.codux.com/kb/en/article/kb37137'}>
-                    <button className="introButton">Learn more</button>
-                </a>
-            </p>
+            <div className={styles.content}>
+                <p className={styles.title}>
+                    HOW TO USE <br /> E-COMMERCE STARTER?
+                </p>
+                <p className={styles.description}>
+                    Welcome to Codux e-commerce starter. <br /> This template was built to help you create your own
+                    store easily. Use Codux to design your website the way you want, and Wix Headless e-commerce
+                    services to manage your store.
+                    <a href={'https://help.codux.com/kb/en/article/kb37137'}>
+                        <button className="introButton">Learn more</button>
+                    </a>
+                </p>
+            </div>
         </div>
     ),
     environmentProps: {

--- a/_codux/boards/intro/intro.module.scss
+++ b/_codux/boards/intro/intro.module.scss
@@ -9,7 +9,6 @@
 }
 
 .content {
-    border-radius: 10px;
     width: 1000px;
 }
 

--- a/_codux/boards/intro/intro.module.scss
+++ b/_codux/boards/intro/intro.module.scss
@@ -1,17 +1,19 @@
 @use '@styles/variables.scss' as *;
 
 .container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+   width: 100%;
+   height: 100vh;
+   display: flex;
+   justify-content: center;
+   align-items: center;
+}
+
+.content {
     border-radius: 10px;
-    display: grid;
-    justify-content: center;
     width: 1000px;
 }
 
-.myStyle {
+.title {
     font: var(--paragraph1);
     color: var(--snow-white);
     padding: 40px 100px;
@@ -23,7 +25,7 @@
     border-radius: 20px 20px 0 0;
 }
 
-.myParagraph {
+.description {
     color: var(--snow-white);
     padding: 70px 120px;
     text-align: center;
@@ -43,15 +45,15 @@
         margin-top: unset;
     }
 
-    .myStyle,
-    .myParagraph {
+    .title,
+    .description {
         padding: 50px 40px;
     }
 }
 
 @media (width <= $mobile-width) {
-    .myStyle,
-    .myParagraph {
+    .title,
+    .description {
         font-size: 20px;
     }
 }

--- a/_codux/boards/intro/intro.module.scss
+++ b/_codux/boards/intro/intro.module.scss
@@ -1,11 +1,11 @@
 @use '@styles/variables.scss' as *;
 
 .container {
-   width: 100%;
-   height: 100vh;
-   display: flex;
-   justify-content: center;
-   align-items: center;
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .content {


### PR DESCRIPTION
Changed structure and styling of the intro board to remove absolute positioning which break board thumbnail preview (there is an issue to fix on Codux side - https://github.com/wixplosives/codux-core/issues/1149)

Before:
<img width="315" alt="Screenshot 2024-10-10 at 12 07 45" src="https://github.com/user-attachments/assets/210711cc-4673-462c-9bc9-bb1970090ac3">

After:
<img width="283" alt="Screenshot 2024-10-10 at 12 08 40" src="https://github.com/user-attachments/assets/eaf92f0a-6442-4d45-979e-70ab81b1297a">
