### PR TITLE
Remove cart loading state

### DIFF
--- a/src/components/cart/cart-view/cart-view.tsx
+++ b/src/components/cart/cart-view/cart-view.tsx
@@ -4,7 +4,7 @@ import { CartItem } from '../cart-item/cart-item';
 import styles from './cart-view.module.scss';
 
 export interface CartViewProps {
-    cart: Cart;
+    cart?: Cart;
     cartTotals?: CartTotals;
     errorMessage?: string;
     onCheckout: () => void;
@@ -20,7 +20,7 @@ export const CartView = ({
     onItemQuantityChange,
     onItemRemove,
 }: CartViewProps) => {
-    if (cart.lineItems.length === 0) {
+    if (!cart || cart.lineItems.length === 0) {
         return <div className={styles.emptyCart}>Cart is empty</div>;
     }
 

--- a/src/components/cart/cart.tsx
+++ b/src/components/cart/cart.tsx
@@ -26,18 +26,14 @@ export const Cart = () => {
 
     return (
         <Drawer title="Cart" onClose={() => setIsOpen(false)} isOpen={isOpen}>
-            {cartData === undefined ? (
-                <div>Loading...</div>
-            ) : (
-                <CartView
-                    cart={cartData}
-                    cartTotals={cartTotals}
-                    errorMessage={errorMessage}
-                    onCheckout={handleCheckout}
-                    onItemRemove={removeItem}
-                    onItemQuantityChange={updateItemQuantity}
-                />
-            )}
+            <CartView
+                cart={cartData}
+                cartTotals={cartTotals}
+                errorMessage={errorMessage}
+                onCheckout={handleCheckout}
+                onItemRemove={removeItem}
+                onItemQuantityChange={updateItemQuantity}
+            />
         </Drawer>
     );
 };


### PR DESCRIPTION
If user opens app for the first time, `getCurrentCart` SDK method returns 404. It means that we don't have information about the cart, but from the user's perspective cart is empty.

In the future PR we probably need to handle cart errors properly - ignore 404 but in case of other errors show message