### PR TITLE
fix: rename and add react-router-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "e-commerce-reclaim",
+  "name": "e-commerce-remix",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "e-commerce-reclaim",
+      "name": "e-commerce-remix",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/is-prop-valid": "^1.3.1",
@@ -49,6 +49,7 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "prettier": "^3.3.3",
+        "react-router-dom": "~6.27.0",
         "sass": "~1.80.5",
         "typescript": "~5.6.3",
         "vite": "^5.4.10",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "e-commerce-reclaim",
+  "name": "e-commerce-remix",
   "version": "0.1.0",
   "private": true,
   "sideEffects": false,
@@ -53,6 +53,7 @@
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "prettier": "^3.3.3",
+    "react-router-dom": "~6.27.0",
     "sass": "~1.80.5",
     "typescript": "~5.6.3",
     "vite": "^5.4.10",


### PR DESCRIPTION
i had to install `react-router-dom` explicitly since nnpm is using linking.
using npm is working locally probably since `react-router-dom` is begin hoisted from another dependency.
`react-router-dom` should not be upgraded since it should match the version that is being retrieved by remix, thats why i used `~` instead of `^`.

Additionally i renamed the the package name since it was changed recently to `reclaim` for some reason.

